### PR TITLE
Add support for endianness in multi-byte constants

### DIFF
--- a/asm.c
+++ b/asm.c
@@ -11,7 +11,7 @@
 
 #include "header.h"
 
-#define NAME_AND_VERSION  "Asm/02 v1.13"
+#define NAME_AND_VERSION  "Asm/02 v1.2"
 
 typedef struct
 {
@@ -1334,15 +1334,33 @@ void processDb(char *args, char typ)
           fixupTypes[numFixups] = 'W';
           numFixups++;
         }
-        output(((num & 0x0000FF00) >> 8) & 0xff);
-        output(num & 0xff);
+        if (endian == BIG_ENDIAN)
+        {
+          output(((num & 0x0000FF00) >> 8) & 0xff);
+          output(num & 0xff);
+        }
+        else
+        {
+          output(num & 0xff);
+          output(((num & 0x0000FF00) >> 8) & 0xff);
+        }
       }
       else
       {
-        output(((num & 0xff000000) >> 24) & 0xff);
-        output(((num & 0x00ff0000) >> 16) & 0xff);
-        output(((num & 0x0000FF00) >> 8) & 0xff);
-        output(num & 0xff);
+        if (endian == BIG_ENDIAN)
+        {
+          output(((num & 0xff000000) >> 24) & 0xff);
+          output(((num & 0x00ff0000) >> 16) & 0xff);
+          output(((num & 0x0000FF00) >> 8) & 0xff);
+          output(num & 0xff);
+        }
+        else
+        {
+          output(num & 0xff);
+          output(((num & 0x0000FF00) >> 8) & 0xff);
+          output(((num & 0x00ff0000) >> 16) & 0xff);
+          output(((num & 0xff000000) >> 24) & 0xff);
+        }
       }
     }
     args = trim(args);
@@ -1371,10 +1389,20 @@ void processDf(char *args)
     buffer[pos] = 0;
     ftoi.f = atof(buffer);
     num = ftoi.i;
-    output(((num & 0xff000000) >> 24) & 0xff);
-    output(((num & 0x00ff0000) >> 16) & 0xff);
-    output(((num & 0x0000FF00) >> 8) & 0xff);
-    output(num & 0xff);
+    if (endian == BIG_ENDIAN)
+    {
+      output(((num & 0xff000000) >> 24) & 0xff);
+      output(((num & 0x00ff0000) >> 16) & 0xff);
+      output(((num & 0x0000FF00) >> 8) & 0xff);
+      output(num & 0xff);
+    }
+    else
+    {
+      output(num & 0xff);
+      output(((num & 0x0000FF00) >> 8) & 0xff);
+      output(((num & 0x00ff0000) >> 16) & 0xff);
+      output(((num & 0xff000000) >> 24) & 0xff);
+    }
     args = trim(args);
     if (*args == ',')
     {
@@ -2201,6 +2229,18 @@ void Asm(char *line)
     {
       suppression = -1;
     }
+    else if (strncasecmp(line, ".endian=big", 11) == 0)
+    {
+      endian = BIG_ENDIAN;
+    }
+    else if (strncasecmp(line, ".endian=little", 14) == 0)
+    {
+      endian = LITTLE_ENDIAN;
+    }
+    else if (strncasecmp(line, ".endian=default", 15) == 0)
+    {
+      endian = defaultEndian;
+    }
     else
     {
       label[0] = *line++;
@@ -2872,6 +2912,8 @@ void processROM(char *buffer)
 #define MCHIP_ARG 0x8A
 #define MINI_ARG  0x8B
 #define MAX_ARG   0x8C
+#define BE_ARG    0x8D
+#define LE_ARG    0x8E
 
 void help()
 {
@@ -2900,6 +2942,8 @@ void help()
           "-ram=low-high - Set explicit RAM region\n"
           "-rom=how-high - Set explicit ROM region\n"
           "-C, -case     - Treat labels as case sensitive\n"
+          "-be           - Set default byte order to big-endian\n"
+          "-le           - Set default byte order to little-endian\n"
           "-v,-version   - Display version information\n"
           "-h,-help      - This message\n");
 }
@@ -2942,6 +2986,8 @@ struct option long_opts[] =
   { "case", no_argument, &labelCase, -1 },
   { "q", no_argument, &quiet, -1},
   { "quiet", no_argument, &quiet, -1},
+  { "be", no_argument, 0, BE_ARG },
+  { "le", no_argument, 0, LE_ARG },
   { 0, 0, 0, 0 }
 };
 
@@ -3044,6 +3090,12 @@ void processOption(int c, int index, char *option)
     romStart = 0xf000;
     romEnd = 0xffff;
     break;
+  case LE_ARG:
+    defaultEndian = LITTLE_ENDIAN;
+    break;
+  case BE_ARG:
+    defaultEndian = BIG_ENDIAN;
+    break;
   }
 }
 
@@ -3063,6 +3115,7 @@ int pass(int p, char* srcFile)
   highAddress = 0x0000;
   strcpy(module, "*");
   fileNumber = 0;
+  endian = defaultEndian;
   sourceFile[0] = fopen(srcFile, "r");
   if (sourceFile[0] == NULL)
   {
@@ -3338,6 +3391,7 @@ int main(int argc, char **argv)
   numIncPath = 0;
   showIncPath = false;
   quiet = false;
+  defaultEndian = BIG_ENDIAN;
   strcpy(lineEnding, "\n");
   tv = time(NULL);
   localtime_r(&tv, &dt);
@@ -3400,7 +3454,7 @@ int main(int argc, char **argv)
     memory = NULL;
 
   for (i=0; i<numSourceFiles; i++)
-         assembleFile(sourceFiles[i]);
+    assembleFile(sourceFiles[i]);
 
   if (errors > 0)
     return 1;

--- a/asm02.doc
+++ b/asm02.doc
@@ -1,28 +1,31 @@
-.1805        - Enable 1805 mode
-.arch=elf2k  - Set Elf2000 memory model
-.arch=mchi   - Set Membership Card high-RAM memory model
-.arch=mchip  - Set MemberCHIP card memory model
-.arch=mclo   - Set Membership Card low-RAM memory model
-.arch=melf   - Set Micro/Elf memory model
-.arch=pev    - Set Pico/Elf memory model
-.arch=pev2   - Set Pico/Elf V2 memory model
-.arch=mini   - Set 1802/Mini memory model
-.arch=max    - Set 1802/MAX memory model
-.align word  - Align address on word boundary (2 bytes)
-.align dword - Align address on double word boundary (4 bytes)
-.align qword - Align address on quad word boundary (8 bytes)
-.align para  - Align address on paragraph boundary (16 bytes)
-.align 32    - Align address on 32-byte boundary
-.align 64    - Align address on 64-byte boundary
-.align 128   - Align address on 128-byte boundary
-.align page  - Align address on page boundary (256 bytes)
-.binary      - Output as binary
-.intel       - Output as Intel hex
-.list        - Enable show list
-.rcs         - Output as Rcs hex
-.sym         - Show symbols
-.link line   - Pass 'line' to linker
-.suppress    - Suppress further byte output
+.1805           - Enable 1805 mode
+.arch=elf2k     - Set Elf2000 memory model
+.arch=mchi      - Set Membership Card high-RAM memory model
+.arch=mchip     - Set MemberCHIP card memory model
+.arch=mclo      - Set Membership Card low-RAM memory model
+.arch=melf      - Set Micro/Elf memory model
+.arch=pev       - Set Pico/Elf memory model
+.arch=pev2      - Set Pico/Elf V2 memory model
+.arch=mini      - Set 1802/Mini memory model
+.arch=max       - Set 1802/MAX memory model
+.align word     - Align address on word boundary (2 bytes)
+.align dword    - Align address on double word boundary (4 bytes)
+.align qword    - Align address on quad word boundary (8 bytes)
+.align para     - Align address on paragraph boundary (16 bytes)
+.align 32       - Align address on 32-byte boundary
+.align 64       - Align address on 64-byte boundary
+.align 128      - Align address on 128-byte boundary
+.align page     - Align address on page boundary (256 bytes)
+.binary         - Output as binary
+.intel          - Output as Intel hex
+.list           - Enable show list
+.rcs            - Output as Rcs hex
+.sym            - Show symbols
+.link line      - Pass 'line' to linker
+.suppress       - Suppress further byte output
+.endian=big     - Set byte order to big-endian
+.endian=little  - Set byte order to little-endian
+.endian=default - Set byte order to default
 .op "opcode","arglist","translation"
    arglist:
      B - byte
@@ -49,8 +52,8 @@ Command line switches:
   -l, -showlist - Show assembly list
   -L, -list     - Create .lst file
   -warnover     - Treat overwriting an address (in binary or Intel mode) as a warning (normally an error)
-  -q, -quiet    - Show minimal output
   -s, -symbols  - Show symbols
+  -q, -quiet    - Show minimal output
   -melf         - Set Micro/Elf memory model
   -pev          - Set Pico/Elf memory model
   -pev2         - Set Pico/Elf V2 memory model
@@ -67,6 +70,8 @@ Command line switches:
   -crlf         - Use CRLF as line ending
   -lfcr         - Use LFCR as line ending
   -C, -case     - Treat labels as case sensitive
+  -be           - Set default byte order to big-endian
+  -le           - Set default byte order to little-endian
   -help, -h     - List of options
 
 Evaluator variables:

--- a/asm02.txt
+++ b/asm02.txt
@@ -1,28 +1,31 @@
-.1805        - Enable 1805 mode
-.arch=elf2k  - Set Elf2000 memory model
-.arch=mchi   - Set Membership Card high-RAM memory model
-.arch=mchip  - Set MemberCHIP card memory model
-.arch=mclo   - Set Membership Card low-RAM memory model
-.arch=melf   - Set Micro/Elf memory model
-.arch=pev    - Set Pico/Elf memory model
-.arch=pev2   - Set Pico/Elf V2 memory model
-.arch=mini   - Set 1802/Mini memory model
-.arch=max    - Set 1802/MAX memory model
-.align word  - Align address on word boundary (2 bytes)
-.align dword - Align address on double word boundary (4 bytes)
-.align qword - Align address on quad word boundary (8 bytes)
-.align para  - Align address on paragraph boundary (16 bytes)
-.align 32    - Align address on 32-byte boundary
-.align 64    - Align address on 64-byte boundary
-.align 128   - Align address on 128-byte boundary
-.align page  - Align address on page boundary (256 bytes)
-.binary      - Output as binary
-.intel       - Output as Intel hex
-.list        - Enable show list
-.rcs         - Output as Rcs hex
-.sym         - Show symbols
-.link line   - Pass 'line' to linker
-.suppress    - Suppress further byte output
+.1805           - Enable 1805 mode
+.arch=elf2k     - Set Elf2000 memory model
+.arch=mchi      - Set Membership Card high-RAM memory model
+.arch=mchip     - Set MemberCHIP card memory model
+.arch=mclo      - Set Membership Card low-RAM memory model
+.arch=melf      - Set Micro/Elf memory model
+.arch=pev       - Set Pico/Elf memory model
+.arch=pev2      - Set Pico/Elf V2 memory model
+.arch=mini      - Set 1802/Mini memory model
+.arch=max       - Set 1802/MAX memory model
+.align word     - Align address on word boundary (2 bytes)
+.align dword    - Align address on double word boundary (4 bytes)
+.align qword    - Align address on quad word boundary (8 bytes)
+.align para     - Align address on paragraph boundary (16 bytes)
+.align 32       - Align address on 32-byte boundary
+.align 64       - Align address on 64-byte boundary
+.align 128      - Align address on 128-byte boundary
+.align page     - Align address on page boundary (256 bytes)
+.binary         - Output as binary
+.intel          - Output as Intel hex
+.list           - Enable show list
+.rcs            - Output as Rcs hex
+.sym            - Show symbols
+.link line      - Pass 'line' to linker
+.suppress       - Suppress further byte output
+.endian=big     - Set byte order to big-endian
+.endian=little  - Set byte order to little-endian
+.endian=default - Set byte order to default
 .op "opcode","arglist","translation"
    arglist:
      B - byte
@@ -67,6 +70,8 @@ Command line switches:
   -crlf         - Use CRLF as line ending
   -lfcr         - Use LFCR as line ending
   -C, -case     - Treat labels as case sensitive
+  -be           - Set default byte order to big-endian
+  -le           - Set default byte order to little-endian
   -help, -h     - List of options
 
 Evaluator variables:

--- a/header.h
+++ b/header.h
@@ -147,6 +147,12 @@ typedef struct Define
   bool visited;
 } Define;
 
+typedef enum Endian
+{
+  BIG_ENDIAN,
+  LITTLE_ENDIAN
+} Endian;
+
 LINK Define *defines;
 LINK int     numDefines;
 LINK char  **clDefines;
@@ -234,4 +240,6 @@ LINK int     fileNumber;
 LINK bool    showIncPath;
 LINK int     labelCase;
 LINK int     quiet;
+LINK Endian  endian;
+LINK Endian  defaultEndian;
 #endif


### PR DESCRIPTION
This merge request enables support for controlling the endianness of constants defined in the assembler via the dw, dd, and df directives. It includes support for command line options to set the default endianness and assembler directives to set the endianness at any point in an assembly source file.